### PR TITLE
Fix linting script error

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
         "eslint.config.js"
     ],
     "scripts": {
-        "lint": "eslint --cache --ext js --ext ts ./",
-        "lint:fix": "eslint --cache --fix --ext js --ext ts ./",
+        "lint": "eslint --cache --ext cjs --ext js --ext ts ./",
+        "lint:fix": "eslint --cache --fix --ext cjs --ext js --ext ts ./",
         "test": "",
         "prepublishOnly": "npm run test && npm run lint",
         "preversion": "npm run lint"


### PR DESCRIPTION
The publish GHA failed because the linting script no longer work, since the linting config was CJS and no JS or TS files were found. By adding CJS to the lint scripts, the publish now works.
![image](https://github.com/user-attachments/assets/22b0730f-a3c4-4599-beb3-6b98ce44a533)
