### PR TITLE
Fix missing config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "eslint-config-lintification",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "eslint-config-lintification",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
                 "@stylistic/eslint-plugin": "2.10.1",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
     "name": "eslint-config-lintification",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A suite of battle-tested linting rules for any modern Node.js application, with full support for the most common TypeScript rules.",
-    "main": "eslint.config.js",
+    "main": ".eslintrc.cjs",
     "files": [
-        "eslint.config.js"
+        ".eslintrc.cjs"
     ],
     "scripts": {
         "lint": "eslint --cache --ext cjs --ext js --ext ts ./",


### PR DESCRIPTION
Originally, we attempted to publish with the flat eslint config format, but instead reverted to the legacy format, but forgot to update package.json whilst doing so.