### PR TITLE
Fix release notes GHA

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,7 +23,7 @@ jobs:
       uses: martinbeentjes/npm-get-version-action@main
     - name: Create Changelog Config
       # For more info on the auto-changelog config params: https://www.npmjs.com/package/auto-changelog/v/2.4.0
-      run: echo '{"output":"CHANGELOG.md","template":"keepachangelog","package":true,"unreleased":false,"commitLimit":false,"sortCommits":"date-desc","issueUrl":"https://github.com/nick-w-nick/eslint-config-lintification/issues/{id}","issuePattern":"\\b(\\d+)\\b}' > .auto-changelog
+      run: echo '{"output":"CHANGELOG.md","template":"keepachangelog","package":true,"unreleased":false,"commitLimit":false,"sortCommits":"date-desc","issueUrl":"https://github.com/nick-w-nick/eslint-config-lintification/issues/{id}","issuePattern":"\\b(\\d+)\\b}"}' > .auto-changelog
     - name: Generate Changelog
       run: npx auto-changelog@2.4.0
     - name: Create Release


### PR DESCRIPTION
The CHANGELOG GHA failed because the JSON was invalid. This is because the config is missing a closing quote and curly bracket.
![image](https://github.com/user-attachments/assets/5bb32be7-7d83-49fc-9ad3-03b50fa92db6)
